### PR TITLE
Better logging of running statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If the time between events is greater the statistic reporting period can be long
 
 Displayed statistics are of the form:
 
-> Received  _eventCount / totalEventCount_  events (processed a,u,d:  _eventCount / totalEventCount_ , _eventCount / totalEventCount_ , _eventCount / totalEventCount_ ); min/max for part  _P_ :  _minOffset / maxOffset_ ; event creation timestamp between  _minDateTime_  and  _maxDateTime_  within  _N_  sec
+> Received  _eventCount / totalEventCount_  events (processed a,u,d:  _eventCount / totalEventCount_ , _eventCount / totalEventCount_ , _eventCount / totalEventCount_ ); min/max for partition  _P_ :  _minOffset / maxOffset_ ; event creation timestamp between  _minDateTime_  and  _maxDateTime_  within  _N_  sec
 
 This will show the number of events within the last period of N seconds and the total number of events for the entire time the application was running. It also shows the number of events (as well as the total) divided by the event type: addition, updates or deletes ('a,u,d'). While the received counters shows all received events (both accepted/processed as well as ignored), the a,u,d will only count the accepted (i.e. processed) events.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ The property "dk.dataforsyningen.vanda_hydrometry_event_consumer.loggingEvents" 
 Running statistics are displayed and logged with level INFO when events are received but with a minimum period define by "dk.dataforsyningen.vanda_hydrometry_event_consumer.reportPeriodSec" in application.properties. 
 If the time between events is greater the statistic reporting period can be longer.
 
+Displayed statistics are of the form:
+
+> Received  _eventCount / totalEventCount_  events (processed a,u,d:  _eventCount / totalEventCount_ , _eventCount / totalEventCount_ , _eventCount / totalEventCount_ ); min/max for part  _P_ :  _minOffset / maxOffset_ ; event creation timestamp between  _minDateTime_  and  _maxDateTime_  within  _N_  sec
+
+This will show the number of events within the last period of N seconds and the total number of events for the entire time the application was running. It also shows the number of events (as well as the total) divided by the event type: addition, updates or deletes ('a,u,d'). While the received counters shows all received events (both accepted/processed as well as ignored), the a,u,d will only count the accepted (i.e. processed) events.
+
+It will also show the minimum and maximum offset value for each partition P, for which events have been received within the last period of N seconds.
+
+It will also show the minium and maximum event timestamp within the period.
+
 ## Usage
 
 This section shows the operations and parameters that can be used with the application. In order to run the application from the command line (console) use this command:

--- a/src/main/java/dk/dataforsyningen/vanda_hydrometry_event_consumer/service/VandaHEventProcessor.java
+++ b/src/main/java/dk/dataforsyningen/vanda_hydrometry_event_consumer/service/VandaHEventProcessor.java
@@ -5,7 +5,11 @@ import dk.dataforsyningen.vanda_hydrometry_event_consumer.config.VandaHEventCons
 import dk.dataforsyningen.vanda_hydrometry_event_consumer.model.EventModel;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +36,9 @@ public class VandaHEventProcessor {
   private long eventCounterAdd = 0L;
   private long eventCounterUpd = 0L;
   private long eventCounterDel = 0L;
+  private long eventCounterAddTotal = 0L;
+  private long eventCounterUpdTotal = 0L;
+  private long eventCounterDelTotal = 0L;
   private long eventCounterTotal = 0L;
   private OffsetDateTime minRecordTime = null;
   private OffsetDateTime maxRecordTime = null;
@@ -89,16 +96,19 @@ public class VandaHEventProcessor {
 
             dbService.addMeasurementFromEvent(event);
             eventCounterAdd++;
+            eventCounterAddTotal++;
 
           } else if (EVENT_MEASUREMENT_UPDATED.equals(event.getEventType())) {
 
             dbService.updateMeasurementFromEvent(event);
             eventCounterUpd++;
+            eventCounterUpdTotal++;
 
           } else if (EVENT_MEASUREMENT_DELETED.equals(event.getEventType())) {
 
             dbService.deleteMeasurementFromEvent(event);
             eventCounterDel++;
+            eventCounterDelTotal++;
           }
         }
       }
@@ -133,27 +143,38 @@ public class VandaHEventProcessor {
 
         String msg =
             "Received " + eventCounter + "/" + eventCounterTotal +
-                " events (a,u,d:" + eventCounterAdd + "," + eventCounterUpd + "," +
-                eventCounterDel +
-                ") " +
-                (lastReportTimestamp > 0 ?
-                    ("within " + (int) ((now - lastReportTimestamp) / 1000) + " sec") : "") +
-                "\n";
+                " events (processed a,u,d:" + eventCounterAdd + "/" + eventCounterAddTotal +  "," 
+            		+ eventCounterUpd + "/" + eventCounterUpdTotal + "," 
+            		+ eventCounterDel + "/" + eventCounterDelTotal + 
+                "); ";
         // reset the event counter within this report period
         eventCounter = 0;
+        //reset event counters
+        eventCounterAdd = eventCounterUpd = eventCounterDel = 0;
 
         //display offset min/max
-        for (int partition : minOffset.keySet()) {
-          // find the oldest offset for this partition
-          long minimumOffset = minOffset.get(partition);
-          // find the newest offset for this partition
-          long maximumOffset = maxOffset.get(partition);
-          msg +=
-              "min/max for part " + partition + ": " + minimumOffset + "/" + maximumOffset + "; ";
+        Iterator<Entry<Integer, Long>> iteratorMin = minOffset.entrySet().iterator();
+        while (iteratorMin.hasNext()) {
+            Map.Entry<Integer, Long> entryMin = iteratorMin.next();
+            int partition = entryMin.getKey();            
+            // find the oldest offset for this partition
+            long minimumOffset = entryMin.getValue();
+            // find the newest offset for this partition
+            long maximumOffset = maxOffset.get(partition);
+            
+            msg += "min/max for part " + partition + ": " + minimumOffset + "/" + maximumOffset + "; ";
+            
+            //reset offset min/max
+            iteratorMin.remove();
+            maxOffset.remove(partition);  
         }
-        msg += "event creation timestamp between " + minRecordTime + " and " + maxRecordTime;
+        msg += "event creation timestamp between " + minRecordTime + " and " + maxRecordTime +
+        		(lastReportTimestamp > 0 ?
+                        (" within " + (int) ((now - lastReportTimestamp) / 1000) + " sec") : "");
         // remember the time when the report is shown
         lastReportTimestamp = now;
+        //reset minRecordTime and maxRecordTime
+        minRecordTime = maxRecordTime = null;
 
         logger.info(msg);
       }

--- a/src/main/java/dk/dataforsyningen/vanda_hydrometry_event_consumer/service/VandaHEventProcessor.java
+++ b/src/main/java/dk/dataforsyningen/vanda_hydrometry_event_consumer/service/VandaHEventProcessor.java
@@ -162,7 +162,7 @@ public class VandaHEventProcessor {
             // find the newest offset for this partition
             long maximumOffset = maxOffset.get(partition);
             
-            msg += "min/max for part " + partition + ": " + minimumOffset + "/" + maximumOffset + "; ";
+            msg += "min/max for partition " + partition + ": " + minimumOffset + "/" + maximumOffset + "; ";
             
             //reset offset min/max
             iteratorMin.remove();


### PR DESCRIPTION
jeg har ændret statistikerne sådan at event counters, min og max værdierne for offset og event timestamp bliver nulstillet efter hver rapportering, ellers giver de ikke meget mening når applikationen køre uden stop for flere dage/uger, etc. Har også forbedret teksten og tilføjet beskrivelse i readme.